### PR TITLE
Update to latest unstable

### DIFF
--- a/configuration/common.nix
+++ b/configuration/common.nix
@@ -24,7 +24,8 @@ in {
   ];
 
   # Set pkgs
-  nixpkgs.pkgs = import nixpkgs { inherit (config.nixpkgs) config; };
+  # NOTE: this always lags one boot (or switch) behind...
+  # TODO: maybe make a warning or something if this discrepancy happens.
   nix.nixPath = [
     "nixpkgs=${nixpkgs}"
     "nixos-config=/etc/nixos/configuration.nix"

--- a/configuration/common.nix
+++ b/configuration/common.nix
@@ -4,7 +4,8 @@
 
 { pkgs, config, lib, ... }:
 
-{
+let nixpkgs = (import ../nix/sources.nix).nixpkgs-channels;
+in {
   imports =
     [
       ./packages/overview.nix
@@ -23,7 +24,11 @@
   ];
 
   # Set pkgs
-  nixpkgs.pkgs = import (import ../nix/sources.nix).nixpkgs-channels { config = config.nixpkgs.config; };
+  nixpkgs.pkgs = import nixpkgs { inherit (config.nixpkgs) config; };
+  nix.nixPath = [
+    "nixpkgs=${nixpkgs}"
+    "nixos-config=/etc/nixos/configuration.nix"
+  ];
 
   # Prevent state from accumulating.
   boot.cleanTmpDir = true; # Clean /tmp on boot.

--- a/configuration/packages/overview.nix
+++ b/configuration/packages/overview.nix
@@ -46,7 +46,8 @@
         xorg.xev
 
 		# Programming languages
-		python3 rustup swift octave
+		python3 rustup octave
+                #swift # Doesn't work on latest unstable
 
 		# Graphical defaults
 		zathura signal-desktop sxiv chromium thunderbird

--- a/hosts/macbook/main.nix
+++ b/hosts/macbook/main.nix
@@ -4,7 +4,7 @@ let nixos-hardware = (import ../../nix/sources.nix).nixos-hardware;
 in {
   imports = [
     ./sync.nix
-    (nixos-hardware + "/apple/macbook-air/6")
+    #(nixos-hardware + "/apple/macbook-air/6")
     ./hardware-configuration.nix
     ../../configuration/common.nix
   ];

--- a/hosts/macbook/main.nix
+++ b/hosts/macbook/main.nix
@@ -4,7 +4,7 @@ let nixos-hardware = (import ../../nix/sources.nix).nixos-hardware;
 in {
   imports = [
     ./sync.nix
-    #(nixos-hardware + "/apple/macbook-air/6")
+    (nixos-hardware + "/apple/macbook-air/6")
     ./hardware-configuration.nix
     ../../configuration/common.nix
   ];
@@ -33,9 +33,15 @@ in {
   hardware.facetimehd.enable = true;
 
   # Battery life tweaks
+  # - view usage with powerstat
   services.tlp = {
     enable = true;
     extraConfig = ''
+      # force battery mode even on AC
+      TLP_DEFAULT_MODE=BAT
+      TLP_PERSISTANT_DEFAULT=1
+
+      # manually set performance policy
       ENERGY_PERF_POLICY_ON_BAT=power
       ENERGY_PERF_POLICY_ON_AC=balance-performance
     '';

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -41,10 +41,10 @@
         "homepage": "https://github.com/NixOS/nixpkgs",
         "owner": "NixOS",
         "repo": "nixpkgs-channels",
-        "rev": "f45ccd9d20b4e90e43c4562b9941ea1dbd8f07a4",
-        "sha256": "10476ij19glhs2yy1pmvm0azd75ifjchpfbljn7h1cnnpii1xprc",
+        "rev": "5717d9d2f7ca0662291910c52f1d7b95b568fec2",
+        "sha256": "17gxd2f622pyss3r6cjngdav6wzdbr31d7bqx9z2lawxg47mmk1l",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs-channels/archive/f45ccd9d20b4e90e43c4562b9941ea1dbd8f07a4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/5717d9d2f7ca0662291910c52f1d7b95b568fec2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This also fixes an issue where NixOS used an older channel for its modules so it would get out of sync with the pinned nixpkgs.